### PR TITLE
Remove deprecation warnings

### DIFF
--- a/closure/goog/dom/BUILD
+++ b/closure/goog/dom/BUILD
@@ -355,7 +355,6 @@ closure_js_library(
         "safe.clutz.d.ts",
         "safe.js",
     ],
-    deprecation = "Please use 'safevalues/dom' instead",
     lenient = True,
     deps = [
         ":asserts",

--- a/closure/goog/html/BUILD
+++ b/closure/goog/html/BUILD
@@ -19,7 +19,6 @@ closure_js_library(
         "legacyconversions.clutz.d.ts",
         "legacyconversions.js",
     ],
-    deprecation = "Please use 'safevalues/restricted/legacy' instead",
     lenient = True,
     deps = [
         ":safehtml",
@@ -37,7 +36,6 @@ closure_js_library(
         "safehtml.clutz.d.ts",
         "safehtml.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":safescript",
@@ -79,7 +77,6 @@ closure_js_library(
         "safescript.clutz.d.ts",
         "safescript.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":trustedtypes",
@@ -95,7 +92,6 @@ closure_js_library(
         "safestyle.clutz.d.ts",
         "safestyle.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":safeurl",
@@ -113,7 +109,6 @@ closure_js_library(
         "safestylesheet.clutz.d.ts",
         "safestylesheet.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":safestyle",
@@ -131,7 +126,6 @@ closure_js_library(
         "safeurl.clutz.d.ts",
         "safeurl.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":trustedresourceurl",
@@ -162,7 +156,6 @@ closure_js_library(
         "testing.clutz.d.ts",
         "testing.js",
     ],
-    deprecation = "Please use 'safevalues/testing/conversions' instead",
     lenient = True,
     deps = [
         ":safehtml",
@@ -195,7 +188,6 @@ closure_js_library(
         "trustedresourceurl.clutz.d.ts",
         "trustedresourceurl.js",
     ],
-    deprecation = "Please use 'safevalues' instead",
     lenient = True,
     deps = [
         ":safescript",
@@ -224,7 +216,6 @@ closure_js_library(
         "uncheckedconversions.clutz.d.ts",
         "uncheckedconversions.js",
     ],
-    deprecation = "Please use 'safevalues/restricted/reviewed' instead",
     lenient = True,
     deps = [
         ":safehtml",

--- a/closure/goog/html/sanitizer/BUILD
+++ b/closure/goog/html/sanitizer/BUILD
@@ -80,9 +80,6 @@ closure_js_library(
         "htmlsanitizer.clutz.d.ts",
         "htmlsanitizer.js",
     ],
-    deprecation = "Please use sanitizeHtml, HtmlSanitizer or HtmlSanitizerBuilder from 'safevalues' instead. " +
-                  "Note: We are aware the safevalues sanitizer doesn't support more niche use cases (see b/298325699). " +
-                  "If you believe you fall in this case, please add a clear explanation to the CL adding you to the visibility allowlist so that we can best help you.",
     lenient = True,
     deps = [
         ":attributeallowlists",


### PR DESCRIPTION
We know the whole library is deprecated, no need to spam us about it

Achieved using:

```
 buildozer 'remove deprecation' '//...:*'
```

Though it was so few changes that hand removing them would have been easy too.